### PR TITLE
Minimum Gradle version in documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ https://github.com/ec4j/editorconfig-gradle-plugin/issues[report] them!
 
 == Basic usage
 
-`editorconfig-gradle-plugin` requires Java 7+ and Gradle 3.5+.
+`editorconfig-gradle-plugin` requires Java 7+ and Gradle 4.1+.
 
 To apply the plugin, add the following to your project:
 


### PR DESCRIPTION
Changed the minimum Gradle version to documentation because of the usage of Worker API that was introduced in Gradle 4.1.