### PR TITLE
chore: Bump linters dependency in build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,15 +54,14 @@ repositories {
 dependencies {
     compileOnly(gradleApi())
     compileOnly(localGroovy())
-    compileOnly("org.ec4j.maven:ec4j-lint-api:0.0.8")
+    implementation("org.ec4j.linters:editorconfig-lint-api:0.2.1")
     // Keep in sync with org.ec4j.gradle.EditorconfigGradlePlugin.LINTERS_VERSION */
 
-    testCompileOnly("junit:junit:4.13.2")
-    testCompileOnly("org.junit.jupiter:junit-jupiter:5.8.1")
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testCompileOnly(gradleTestKit())
     testCompileOnly("org.slf4j:slf4j-api:1.7.30")
     testCompileOnly("org.slf4j:slf4j-simple:1.7.30")
-    testCompileOnly("org.ec4j.maven:ec4j-lint-api:0.0.8")
 }
 
 gradlePlugin {

--- a/src/main/java/org/ec4j/gradle/EditorconfigGradlePlugin.java
+++ b/src/main/java/org/ec4j/gradle/EditorconfigGradlePlugin.java
@@ -27,8 +27,8 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
  */
 public class EditorconfigGradlePlugin implements Plugin<Project> {
     public static final String CONFIGURATION_NAME = "editorconfig";
-    /** The version of {@code org.ec4j.maven:ec4j-linters} keep in sync with the version in {@code build.gradle} */
-    private static final String LINTERS_VERSION = "0.0.8";
+    /** The version of {@code org.ec4j.linters:editorconfig-linters} keep in sync with the version in {@code build.gradle} */
+    private static final String LINTERS_VERSION = "0.2.1";
 
     /** {@inheritDoc} */
     @Override
@@ -37,7 +37,7 @@ public class EditorconfigGradlePlugin implements Plugin<Project> {
         project.getRepositories().add(project.getRepositories().mavenCentral());
         project.getConfigurations().maybeCreate(CONFIGURATION_NAME);
         final DependencyHandler dependencies = project.getDependencies();
-        dependencies.add(CONFIGURATION_NAME, "org.ec4j.maven:ec4j-linters:" + LINTERS_VERSION);
+        dependencies.add(CONFIGURATION_NAME, "org.ec4j.linters:editorconfig-linters:" + LINTERS_VERSION);
 
         project.getTasks().create(EditorconfigCheckTask.NAME, EditorconfigCheckTask.class);
         project.getTasks().create(EditorconfigFormatTask.NAME, EditorconfigFormatTask.class);

--- a/src/main/java/org/ec4j/gradle/runtime/EditorconfigInvoker.java
+++ b/src/main/java/org/ec4j/gradle/runtime/EditorconfigInvoker.java
@@ -34,7 +34,6 @@ import org.ec4j.gradle.CollectingLogger;
 import org.ec4j.gradle.EditorconfigCheckTask;
 import org.ec4j.gradle.EditorconfigFormatTask;
 import org.ec4j.gradle.LinterConfig;
-import org.ec4j.lint.api.EditableResource;
 import org.ec4j.lint.api.FormatException;
 import org.ec4j.lint.api.FormattingHandler;
 import org.ec4j.lint.api.Linter;
@@ -108,7 +107,7 @@ public class EditorconfigInvoker implements Runnable {
             this.resourceFactory = new ResourceFactory() {
                 @Override
                 public Resource createResource(Path absFile, Path relFile, Charset encoding) {
-                    return new EditableResource(absFile, relFile, encoding);
+                    return new Resource(absFile, relFile, encoding);
                 }
             };
         } else {


### PR DESCRIPTION
I created a `Linter` implementation which integrates Intellij CE formatter: https://github.com/kamil-perczynski/javalint.

It works correctly with (https://github.com/ec4j/editorconfig-maven-plugin), however due to outdated dependencies it cannot be used with Gradle plugin.

Should fix #12 as well 