### PR TITLE
fix: editorconfig-linters dependency declaration scope

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,10 +52,12 @@ repositories {
 }
 
 dependencies {
+    val ec4jLintersVersion = "0.2.1"
+
     compileOnly(gradleApi())
     compileOnly(localGroovy())
-    implementation("org.ec4j.linters:editorconfig-lint-api:0.2.1")
-    // Keep in sync with org.ec4j.gradle.EditorconfigGradlePlugin.LINTERS_VERSION */
+    implementation("org.ec4j.linters:editorconfig-linters:$ec4jLintersVersion")
+    implementation("org.ec4j.linters:editorconfig-lint-api:$ec4jLintersVersion")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")

--- a/src/main/java/org/ec4j/gradle/EditorconfigGradlePlugin.java
+++ b/src/main/java/org/ec4j/gradle/EditorconfigGradlePlugin.java
@@ -18,7 +18,6 @@ package org.ec4j.gradle;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.dsl.DependencyHandler;
 
 /**
  * Adds {@link EditorconfigExtension}, {@link EditorconfigCheckTask} and {@link EditorconfigFormatTask}.
@@ -27,17 +26,12 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
  */
 public class EditorconfigGradlePlugin implements Plugin<Project> {
     public static final String CONFIGURATION_NAME = "editorconfig";
-    /** The version of {@code org.ec4j.linters:editorconfig-linters} keep in sync with the version in {@code build.gradle} */
-    private static final String LINTERS_VERSION = "0.2.1";
 
     /** {@inheritDoc} */
     @Override
     public void apply(Project project) {
         project.getExtensions().create(EditorconfigExtension.NAME, EditorconfigExtension.class);
-        project.getRepositories().add(project.getRepositories().mavenCentral());
         project.getConfigurations().maybeCreate(CONFIGURATION_NAME);
-        final DependencyHandler dependencies = project.getDependencies();
-        dependencies.add(CONFIGURATION_NAME, "org.ec4j.linters:editorconfig-linters:" + LINTERS_VERSION);
 
         project.getTasks().create(EditorconfigCheckTask.NAME, EditorconfigCheckTask.class);
         project.getTasks().create(EditorconfigFormatTask.NAME, EditorconfigFormatTask.class);


### PR DESCRIPTION
Closes #10, but requires some discussion imho.

Although I understand the intent behind direct dependency only on the `editorconfig-lint-api` and narrowing the scope of the `editorconfig-linters`, hard-coded adding `mavenCentral()` causes issues in environments where manual repositories resolution is required: [custom repositories resolution](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:centralized-repository-declaration).

Specifically, I think about environments where access to software repositories is restricted/proxied due to security reasons (described in #10, I have recent professional experience with such setup - becoming an industry standard I suppose).

Declaring linters package as `implementation` dependency looks like reasonable step:

* Sync with dependencies declaration with `ec4j-maven-plugin`
* Repositories configuration is 100% on the user side

 

 